### PR TITLE
Implement snapshot command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ godo-cli
 
 # other undesirables
 *.swp
+*.orig

--- a/README.md
+++ b/README.md
@@ -14,18 +14,20 @@ DigitalOcean API v2 command line tool for interacting with your [DigitalOcean](h
 
 
 ## Installation
-```bash
-    $ go get -u github.com/masayukioguni/godo-cli # -u updates your previous install, stay current!
-```
+
+    $ go get -u github.com/masayukioguni/godo-cli
+
+-u switch updates your previous install, stay current!
 
 ## Configuration
 
 ### Authorize
+
 Run the configuration utility, `godo-cli authorize`. You can grab your keys
 [here](https://cloud.digitalocean.com/settings/applications).
 
     $ godo-cli authorize
-    Entser your API key:foo
+    Enter your API key:foo
     
     Authentication with DigitalOcean was successful!
 
@@ -61,8 +63,15 @@ Run the configuration utility, `godo-cli authorize`. You can grab your keys
 You can either power on, off or cycle a droplet
 
     $ godo-cli power -id=3395702 -mode=on # power on droplet id 
-    $ godo-cli power -id=foo -mode=cycle # power cycle (off to on) droplet by name 
+    $ godo-cli power -name=foo -mode=cycle # power cycle (off to on) droplet by name 
 
+
+### Take a snapshot of your droplet
+
+    $ godo-cli snapshot -id=3395702 -snapshot=fizz # create a snapshot called fizz for a droplet by id
+    $ godo-cli snapshot -name=foo -snapshot=buzz # create a snapshot called buzz for a droplet by name 
+
+N.B. Your droplet needs to be powered off.
 
 ### Destroy a droplet
 
@@ -82,7 +91,6 @@ list images provided by DigitalOcean as well.
     668.2.0 (alpha) (id: 11657005, distro: CoreOS) coreos-alpha
     ...
 
-   
 ### List Available Sizes
 
     $ godo-cli sizes
@@ -136,7 +144,8 @@ You can create a new issue [here](https://github.com/masayukioguni/godo-cli/issu
 
 ## History
 
-+ 0.0.2 Added power command
++ 0.0.3 Added snapshot droplet command
++ 0.0.2 Added power droplet command
 + 0.0.1 first release
 
 

--- a/command/authorize.go
+++ b/command/authorize.go
@@ -33,7 +33,7 @@ func (c *AuthorizeCommand) ask(text string, defaultText string) string {
 }
 
 func (c *AuthorizeCommand) Run(args []string) int {
-	apikey := c.ask("Entser your API Token:", "Input api ooken")
+	apikey := c.ask("Enter your API Token:", "Input api token")
 	fmt.Println(`Defaults can be changed at any time in your ~/.godo-cli/config.yaml configuration file.`)
 
 	c.Config.Authentication.APIKey = apikey

--- a/command/snapshot.go
+++ b/command/snapshot.go
@@ -1,0 +1,90 @@
+package command
+
+import (
+	"flag"
+	"fmt"
+	"github.com/digitalocean/godo"
+	"github.com/mitchellh/cli"
+	"strings"
+)
+
+type SnapshotCommand struct {
+	Ui     cli.Ui
+	Client *godo.Client
+}
+
+func (c *SnapshotCommand) Help() string {
+	helpText := `
+	Usage: godo-cli snapshot [options] 
+  
+Options:
+  -id=int The id of the droplet
+  -name=string The name of the droplet
+  -snapshot=Name of snapshot [mandatory]
+
+e.g.
+  godo-cli snapshot -id=droplet id -snapshot=foo
+  godo-cli snapshot -name=droplet name  -snapshot=foo
+   
+`
+	return strings.TrimSpace(helpText)
+}
+
+func (c *SnapshotCommand) SnapshotById(id int, snapshot string) error {
+	_, _, err := c.Client.DropletActions.Snapshot(id, snapshot)
+
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (c *SnapshotCommand) Run(args []string) int {
+	cmdFlags := flag.NewFlagSet("build", flag.ContinueOnError)
+
+	var id = 0
+	var name = ""
+	var snapshot = ""
+	cmdFlags.IntVar(&id, "id", 0, "")
+	cmdFlags.StringVar(&name, "name", "", "")
+	cmdFlags.StringVar(&snapshot, "snapshot", "", "")
+
+	err := cmdFlags.Parse(args)
+
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to parse %v", err))
+		return -1
+	}
+
+	if name == "" && id == 0 && snapshot == "" {
+		c.Help()
+		return -1
+	}
+
+	if name != "" {
+		util := GodoUtil{Client: c.Client}
+		droplet, err := util.GetDropletByName(name)
+
+		if err != nil {
+			c.Ui.Error(fmt.Sprintf("Failed to get droplet id for %s: %v", name, err))
+			return -1
+		}
+
+		id = droplet.ID
+	}
+	err = c.SnapshotById(id, snapshot)
+
+	if err != nil {
+		c.Ui.Error(fmt.Sprintf("Failed to request %v", err))
+		return -1
+	}
+
+	c.Ui.Output(fmt.Sprintf("Queuing snapshot for %d ...done\n", id))
+
+	return 0
+}
+
+func (c *SnapshotCommand) Synopsis() string {
+	return fmt.Sprintf("Create a snapshot of a droplet.")
+}

--- a/command/snapshot_test.go
+++ b/command/snapshot_test.go
@@ -1,0 +1,18 @@
+package command
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestCommond_SnapshotSynopsis(t *testing.T) {
+	command := &SnapshotCommand{
+		Client: nil,
+	}
+
+	wantSynopsis := "Create a snapshot of a droplet."
+	if !reflect.DeepEqual(command.Synopsis(), wantSynopsis) {
+		t.Errorf("SnapshotCommand.Synopsis returned %+v, want %+v", command.Synopsis(), wantSynopsis)
+	}
+
+}

--- a/main.go
+++ b/main.go
@@ -4,7 +4,8 @@ import (
 	"code.google.com/p/goauth2/oauth"
 	"fmt"
 	"github.com/digitalocean/godo"
-	"github.com/masayukioguni/godo-cli/command"
+	// "github.com/masayukioguni/godo-cli/command"
+	"github.com/booyaa/godo-cli/command"
 	"github.com/masayukioguni/godo-cli/config"
 
 	"github.com/mitchellh/cli"
@@ -14,7 +15,7 @@ import (
 var GitCommit string
 
 const ApplicationName = "godo-cli"
-const Version = "0.0.1"
+const Version = "0.0.2a"
 
 func getClinet(accessToken string) *godo.Client {
 
@@ -136,6 +137,12 @@ func main() {
 		},
 		"ssh": func() (cli.Command, error) {
 			return &command.SSHCommand{
+				Ui:     ui,
+				Client: godoCli,
+			}, nil
+		},
+		"power": func() (cli.Command, error) {
+			return &command.PowerCommand{
 				Ui:     ui,
 				Client: godoCli,
 			}, nil

--- a/main.go
+++ b/main.go
@@ -6,7 +6,6 @@ import (
 	"github.com/digitalocean/godo"
 	"github.com/masayukioguni/godo-cli/command"
 	"github.com/masayukioguni/godo-cli/config"
-
 	"github.com/mitchellh/cli"
 	"os"
 )

--- a/main.go
+++ b/main.go
@@ -3,8 +3,8 @@ package main
 import (
 	"code.google.com/p/goauth2/oauth"
 	"fmt"
+	"github.com/booyaa/godo-cli/command"
 	"github.com/digitalocean/godo"
-	"github.com/masayukioguni/godo-cli/command"
 	"github.com/masayukioguni/godo-cli/config"
 	"github.com/mitchellh/cli"
 	"os"
@@ -13,7 +13,7 @@ import (
 var GitCommit string
 
 const ApplicationName = "godo-cli"
-const Version = "0.0.2"
+const Version = "0.0.3"
 
 func getClinet(accessToken string) *godo.Client {
 
@@ -141,6 +141,12 @@ func main() {
 		},
 		"power": func() (cli.Command, error) {
 			return &command.PowerCommand{
+				Ui:     ui,
+				Client: godoCli,
+			}, nil
+		},
+		"snapshot": func() (cli.Command, error) {
+			return &command.SnapshotCommand{
 				Ui:     ui,
 				Client: godoCli,
 			}, nil


### PR DESCRIPTION
usage

```
godo-cli snapshot -name=foo -snapshot=bar
```

will create a snapshot image called bar for droplet named foo.

requires droplet to be powered down and will error accordingly if this is not done.

bumped version to 0.0.3, added to readme.md and fixed a typo in authorized.

thanks again for allow me to contribute to this awesome tool!

closes #28 
